### PR TITLE
Update Makefile to use environment variables instead of relative paths in .d files

### DIFF
--- a/libHSAIL/Makefile
+++ b/libHSAIL/Makefile
@@ -274,28 +274,28 @@ $(LIBHSAIL_DIR)/%.d: $(LIBHSAIL_DIR)/%.cpp
 	@set -e; rm -f $@; \
 	$(CXX) -MM $(INCLUDES) $< > $@.$$$$; \
 	sed -e 's,\([a-Az-Z0-9]*\)\.o[ :]*,\$$\(BUILD_DIR\)/o_\$$\(LIBHSAIL_DIR\)/\1.o $@ : ,g' \
-	    -e 's,$(LLVM_SRC)/include,\$$\(LLVM_SRC\)/include, g' \
-	    -e 's,$(LLVM_BUILD)/include,\$$\(LLVM_BUILD\)/include, g' \
+	    -e 's,$(LLVM_SRC),\$$\(LLVM_SRC\), g' \
+	    -e 's,$(LLVM_BUILD),\$$\(LLVM_BUILD\), g' \
 	    < $@.$$$$ > $@; \
-	rm -f $@.$$$$
+	rm -f $@.$$$$;
 
 $(LIBBRIGDWARF_DIR)/%.d: $(LIBBRIGDWARF_DIR)/%.cpp
 	@set -e; rm -f $@; \
 	$(CXX) -MM $(INCLUDES) $< > $@.$$$$; \
 	sed -e 's,\([a-Az-Z0-9]*\)\.o[ :]*,\$$\(BUILD_DIR\)/o_\$$\(LIBBRIGDWARF_DIR\)/\1.o $@ :,g' \
-	    -e 's,$(LLVM_SRC)/include,\$$\(LLVM_SRC\)/include, g' \
-	    -e 's,$(LLVM_BUILD)/include,\$$\(LLVM_BUILD\)/include, g' \
+	    -e 's,$(LLVM_SRC),\$$\(LLVM_SRC\), g' \
+	    -e 's,$(LLVM_BUILD),\$$\(LLVM_BUILD\), g' \
 	    < $@.$$$$ > $@; \
-	rm -f $@.$$$$
+	rm -f $@.$$$$;
 
 $(HSAILASM_DIR)/%.d: $(HSAILASM_DIR)/%.cpp
 	@set -e; rm -f $@; \
 	$(CXX) -MM $(INCLUDES) $< > $@.$$$$; \
 	sed -e 's,\([a-Az-Z0-9]*\)\.o[ :]*,\$$\(BUILD_DIR\)/o_\$$\(HSAILASM_DIR\)/\1.o $@ : ,g' \
-	    -e 's,$(LLVM_SRC)/include,\$$\(LLVM_SRC\)/include, g' \
-	    -e 's,$(LLVM_BUILD)/include,\$$\(LLVM_BUILD\)/include, g' \
+	    -e 's,$(LLVM_SRC),\$$\(LLVM_SRC\), g' \
+	    -e 's,$(LLVM_BUILD),\$$\(LLVM_BUILD\), g' \
 	    < $@.$$$$ > $@; \
-	rm -f $@.$$$$
+	rm -f $@.$$$$;
 #############################################
 # universal rule for object files
 $(BUILD_DIR)/o_%$(OBJ_SUFFIX): %.cpp


### PR DESCRIPTION
Update Makefile to use environment variables instead of relative paths in .d files
