### PR TITLE
Valgrind Error:Conditional jump or move depends on uninitialised value

### DIFF
--- a/libHSAIL/libHSAIL/HSAILBrigObjectFile.cpp
+++ b/libHSAIL/libHSAIL/HSAILBrigObjectFile.cpp
@@ -600,20 +600,23 @@ int BrigIO::load(BrigContainer &dst,
                  ReadAdapter&  src)
 {
     unsigned char ident[16];
-    src.pread((char*)ident, 16, 0);
-    switch(ident[EI_CLASS]) {
-    case ELFCLASS32: {
-        BrigIOImpl<Elf32Policy> impl(fmt);
-        return impl.readContainer(dst, &src);
-        }
-    case ELFCLASS64: {
-        BrigIOImpl<Elf64Policy> impl(fmt);
-        return impl.readContainer(dst, &src);
-        }
-    default:
-        src.errs << "Invalid ELFCLASS";
-        return 1;
-    }
+    if (!(src.pread((char*)ident, 16, 0))) {
+			switch(ident[EI_CLASS]) {
+			case ELFCLASS32: {
+					BrigIOImpl<Elf32Policy> impl(fmt);
+					return impl.readContainer(dst, &src);
+					}
+			case ELFCLASS64: {
+					BrigIOImpl<Elf64Policy> impl(fmt);
+					return impl.readContainer(dst, &src);
+					}
+			default:
+					src.errs << "Invalid ELFCLASS";
+					return 1;
+			}
+		} else {
+			return 1;
+		}
 }
 
 int BrigIO::save(BrigContainer &src, 


### PR DESCRIPTION
Getting Valgrind error:
Conditional jump or move depends on uninitialised value(s)

After debug the error is found to be in the function
int BrigIO::load(BrigContainer &dst, int fmt, ReadAdapter&  src) in HSAILBrigObjectFile.cpp  file, as missing check.

The small test case to reproduce similar error:
[if a.txt is empty]
# include<unistd.h>
# include<stdio.h>
# include<fcntl.h>

int main()
{
     unsigned char data[16];
     char *filename = "a.txt";
     int fd = open(filename, O_RDONLY, 0666);
     int rc = read(fd, data, 16);
     if (data[0] == '\n') printf("Success\n"); // rc && data[0]
return 1;
}
