### PR TITLE
add -fpic compiling libHSAIL, needed to build the LLVM compiler

### DIFF
--- a/libHSAIL/libHSAIL/CMakeLists.txt
+++ b/libHSAIL/libHSAIL/CMakeLists.txt
@@ -1,5 +1,9 @@
 find_package(Perl REQUIRED)
 
+if(UNIX)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic")
+endif()
+
 set(libhsail_public_headers
   Brig.h
   HSAILBrigContainer.h


### PR DESCRIPTION
Adding the -fpic option to generate position independent code when compiling the objs in libhsail.a.  That's needed when creating a shared library that links against libhsail.a