### PR TITLE
Remove re2c return value check

### DIFF
--- a/cmake_modules/FindRE2C.cmake
+++ b/cmake_modules/FindRE2C.cmake
@@ -16,11 +16,7 @@ if(RE2C_EXECUTABLE)
 		ERROR_VARIABLE RE2C_version_error
 		OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-	if(RE2C_version_result EQUAL 0)
-		message(SEND_ERROR "Command \"${RE2C_EXECUTABLE} --vernum\" failed with output:\n${RE2C_version_error}")
-	else()
-		set(RE2C_VERSION ${RE2C_version_output})
-	endif()
+	set(RE2C_VERSION ${RE2C_version_output})
 
 	macro(RE2C_TARGET Re2cInput Re2cOutput Args)
 		set(RE2C_EXECUTABLE_opts ${Args})


### PR DESCRIPTION
In Ubuntu 16.04 shipped with re2c 0.16, the return value of re2c --vernum would
be 0, thus failing existing check logic. Remove it in this commit.