### PR TITLE
Sort hash keys

### DIFF
--- a/libHSAIL/generate.pl
+++ b/libHSAIL/generate.pl
@@ -1783,7 +1783,7 @@ sub registerProp {
 sub getBrigPropByType {
     my ($type) = @_;
 
-    for my $prop (keys %brigProps) {
+    for my $prop (sort keys %brigProps) {
         my ($ty, $acc) = @{$brigProps{$prop}};
         if ($ty eq $type) { return $prop; }
     }


### PR DESCRIPTION
to always generate the same HSAILBrigEnum2str_gen.hpp output
which influenced libhsail.so

See https://reproducible-builds.org/ for why this is good.