### PR TITLE
Fix for issue #52

### DIFF
--- a/libHSAIL/HSAILBrigObjectFile.h
+++ b/libHSAIL/HSAILBrigObjectFile.h
@@ -105,7 +105,7 @@ public:
 
     template <typename T, unsigned N>
     int write(const T (&a)[N], unsigned numElems = 0) {
-        return write((const char*)a, sizeof a[0] * numElems? numElems : N);
+        return write((const char*)a, sizeof(a[0]) * (numElems != 0 ? numElems : N));
     }
 };
 


### PR DESCRIPTION
Multiplication has higher precedence than ternary operator. So `a[0] * numElems` is computed first and used as the 1st operand of `?:`. This seems semantically wrong and also causes the warning (because the 1st operand of `?:` has boolean context).

Parntheses around `a[0]` are not actually required, but with these the code looks clearer to me.