### PR TITLE
Sort another hash iterator

### DIFF
--- a/libHSAIL/generate.pl
+++ b/libHSAIL/generate.pl
@@ -1376,7 +1376,7 @@ sub makeWrappers {
     print map { "class $_->{wname};\n" } grep { !$_->{nowrap} } @sortedStructs;
     print "\n\n";
 
-    for my $tname (keys %$typedefs) {
+    for my $tname (sort keys %$typedefs) {
 
         my $type = $typedefs->{$tname};
         my $prop = $type->{'bitmask'};


### PR DESCRIPTION
Sort another hash iterator
to produce stable output.

Without this patch, HSAILItems_gen.hpp
got variations in the order of BrigAluModifier and BrigExecutableModifier

Similar to commit 91669c2fea8d93d4e1b22963b438201ad3115dfa
for reproducible builds.

I think, I did not notice it back then, because it is just 1 bit of entropy,
so 50% of the time, you can get 2 identical builds.