### PR TITLE
Remove unused 'ctxMarker' variables

### DIFF
--- a/libHSAIL/HSAILScannerRules.re2c
+++ b/libHSAIL/HSAILScannerRules.re2c
@@ -44,7 +44,6 @@
     re2c:define:YYCURSOR = curPos;
     re2c:define:YYLIMIT  = m_end;
     re2c:define:YYMARKER = marker;
-    re2c:define:YYCTXMARKER = ctxMarker;
     re2c:yyfill:enable   = 0;
     re2c:yych:conversion = 0;
 
@@ -145,7 +144,6 @@ ETokens Scanner::scanModifier(EScanContext ctx, Scanner::Token &t)
     const char* &curPos = t.m_text.end;
     int &brigId = t.m_brigId;
     const char *marker = NULL;
-    const char *ctxMarker = NULL;
 /*!re2c
     re2c:indent:string = "    ";
 
@@ -204,7 +202,6 @@ ETokens Scanner::scanDefault(EScanContext ctx, Scanner::Token &t)
     const char* &curPos = t.m_text.end;
     int &brigId = t.m_brigId;
     const char *marker = NULL;
-    const char *ctxMarker = NULL;
 /*!re2c
     re2c:indent:string  = "        ";
 


### PR DESCRIPTION
On powerpc64le-unknown-linux-gnu, 'g++ (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0', a
plain 'cmake && make' build fails:

    [ 36%] Building CXX object libHSAIL/CMakeFiles/hsail.dir/HSAILScannerRules.cpp.o
    In file included from [...]/libHSAIL/HSAILScannerRules.cpp:46:0:
    [...]/libHSAIL/generated/HSAILScannerRules_gen_re2c.hpp: In member function 'HSAIL_ASM::ETokens HSAIL_ASM::Scanner::scanModifier(HSAIL_ASM::EScanContext, HSAIL_ASM::Scanner::Token&)':
    [...]/libHSAIL/generated/HSAILScannerRules_gen_re2c.hpp:271:17: error: unused variable 'ctxMarker' [-Werror=unused-variable]
         const char *ctxMarker = NULL;
                     ^~~~~~~~~
    [...]/libHSAIL/generated/HSAILScannerRules_gen_re2c.hpp: In member function 'HSAIL_ASM::ETokens HSAIL_ASM::Scanner::scanDefault(HSAIL_ASM::EScanContext, HSAIL_ASM::Scanner::Token&)':
    [...]/libHSAIL/generated/HSAILScannerRules_gen_re2c.hpp:14065:17: error: unused variable 'ctxMarker' [-Werror=unused-variable]
         const char *ctxMarker = NULL;
                     ^~~~~~~~~
    cc1plus: all warnings being treated as errors
    libHSAIL/CMakeFiles/hsail.dir/build.make:346: recipe for target 'libHSAIL/CMakeFiles/hsail.dir/HSAILScannerRules.cpp.o' failed
    make[2]: *** [libHSAIL/CMakeFiles/hsail.dir/HSAILScannerRules.cpp.o] Error 1
    CMakeFiles/Makefile2:87: recipe for target 'libHSAIL/CMakeFiles/hsail.dir/all' failed
    make[1]: *** [libHSAIL/CMakeFiles/hsail.dir/all] Error 2
    Makefile:140: recipe for target 'all' failed
    make: *** [all] Error 2

In the generated file 'libHSAIL/generated/HSAILScannerRules_gen_re2c.hpp', the
'libHSAIL/HSAILScannerRules.re2c' change only removes the two 'ctxMarker'
variables, and doesn't cause any other changes, so presumably they're unused,
and can be removed, together with 're2c:define:YYCTXMARKER'.